### PR TITLE
Fix type mismatch

### DIFF
--- a/res/shader/blur.fs
+++ b/res/shader/blur.fs
@@ -22,7 +22,7 @@
 
 uniform float radius;
 const vec2 dir = vec2(2.0, 2.0);
-const float res = 200;
+const float res = 200.0;
 
 vec4 effect( vec4 color, sampler2D texture, vec2 texture_coords, vec2 screen_coords )
 {


### PR DESCRIPTION
200 is an integer in GLSL, whereas 200.0 is a float, GLSL ES doesn't
implicitly convert literal integers to floats when assigning them to a
variable- Thanks to slime for his help
